### PR TITLE
Allow snappy to be run in GHCi on Windows

### DIFF
--- a/snappy.cabal
+++ b/snappy.cabal
@@ -25,7 +25,15 @@ extra-source-files:
 library
   c-sources:       cbits/hs_snappy.cpp
   include-dirs:    include
-  extra-libraries: snappy stdc++
+  extra-libraries: snappy
+
+  if os(windows)
+    if arch(x86_64)
+      extra-libraries: stdc++-6 gcc_s_seh-1
+    else
+      extra-libraries: stdc++-6 gcc_s_dw2-1
+  else
+    extra-libraries: stdc++
 
   cc-options:      -Wall
   ghc-options:     -Wall


### PR DESCRIPTION
Currently, you can't load `snappy` into GHCi on Windows:

```
ghc.exe: unable to load package `snappy-0.2.0.2'
ghc.exe: C:\Users\RyanGlScott\Documents\Hacking\Haskell\snappy\dist\snappy-0.2.0.2\dist\build\HSsnappy-0.2.0.2-JmBPG2tqLTy4WK0LWtFxMV.o: unknown symbol `_Unwind_Resume'
```

For the same reasons laid out in https://github.com/bos/double-conversion/pull/13. Luckily, the fix is the same as https://github.com/bos/double-conversion/pull/13.