### PR TITLE
Fix testsuite compilation

### DIFF
--- a/snappy.cabal
+++ b/snappy.cabal
@@ -45,6 +45,7 @@ test-suite tests
   type:           exitcode-stdio-1.0
   hs-source-dirs: tests
   main-is:        Properties.hs
+  other-modules:  Functions
 
   ghc-options:
     -Wall -threaded -O0 -rtsopts


### PR DESCRIPTION
`snappy.cabal` forgot to list `Functions` as an `other-module`. Fixes #1.