### PR TITLE
Disable RTTI in C++ source

### DIFF
--- a/snappy.cabal
+++ b/snappy.cabal
@@ -1,3 +1,4 @@
+cabal-version:  2.2
 name:           snappy
 version:        0.2.0.2
 homepage:       http://github.com/bos/snappy
@@ -7,14 +8,13 @@ synopsis:
 description:
   This library provides fast, pure Haskell bindings to Google's Snappy
   compression and decompression library: <http://code.google.com/p/snappy/>
-license:        BSD3
+license:        BSD-3-Clause
 license-file:   LICENSE
 author:         Bryan O'Sullivan <bos@serpentine.com>
 maintainer:     Bryan O'Sullivan <bos@serpentine.com>
 copyright:      Copyright 2011 MailRank, Inc.
 category:       Codec, Compression
 build-type:     Simple
-cabal-version:  >= 1.8
 extra-source-files:
   README.md
   include/hs_snappy.h
@@ -23,11 +23,11 @@ extra-source-files:
   tests/Speedy.hs
 
 library
-  c-sources:       cbits/hs_snappy.cpp
+  cxx-sources:     cbits/hs_snappy.cpp
   include-dirs:    include
   extra-libraries: snappy stdc++
 
-  cc-options:      -Wall
+  cxx-options:     -Wall -fno-rtti
   ghc-options:     -Wall
 
   build-depends:   base < 5, bytestring


### PR DESCRIPTION
This fixes a linker issue with libsnappy-1.1.9. Namely, RTTI has been disabled in 1.1.9 (see https://github.com/google/snappy/commit/c98344f6260d24d921e5e04006d4bedb528f404a), but the haskell package is still compiling its C++ source file with RTTI enabled, which results in an unresolvable symbol (a typeinfo structure).

This PR migrates the cabal file to 2.2, and sets the cxx-sources and cxx-options field (just like https://github.com/bos/snappy/pull/6) in order to disable RTTI.

## More information

The `libsnappy-1.1.9` shared object does not have any typeinfo symbols:

```
$ objdump -T /usr/lib/libsnappy.so | c++filt | grep typeinfo || echo "no matches"
no matches
```

Before this patch:

```
$ objdump -T dist-newstyle/build/x86_64-linux/ghc-8.10.4/snappy-0.2.0.2/build/libHSsnappy-0.2.0.2-inplace-ghc8.10.4.so | c++filt | grep typeinfo || echo "no matches"
0000000000000000      DO *UND*  0000000000000000              typeinfo for snappy::Source
0000000000008370  w   DO .rodata  000000000000000a  Base        typeinfo name for BSSource
0000000000009b90  w   DO .data.rel.ro 0000000000000018  Base        typeinfo for BSSource
```

After this patch:

```
$ objdump -T dist-newstyle/build/x86_64-linux/ghc-8.10.4/snappy-0.2.0.2/build/libHSsnappy-0.2.0.2-inplace-ghc8.10.4.so | c++filt | grep typeinfo || echo "no matches"
no matches
```
