### PR TITLE
Fix build errors

### DIFF
--- a/Codec/Compression/Snappy/Lazy.hsc
+++ b/Codec/Compression/Snappy/Lazy.hsc
@@ -57,6 +57,7 @@ instance Storable BS where
       (#poke struct BS, off) ptr (0::CSize)
       (#poke struct BS, len) ptr len
     {-# INLINE poke #-}
+    peek _ = undefined -- To silence the warning of -Wmissing-method
 
 -- | Compress data into the Snappy format.
 compress :: ByteString -> ByteString

--- a/cbits/hs_snappy.cpp
+++ b/cbits/hs_snappy.cpp
@@ -28,7 +28,7 @@ int _hsnappy_RawUncompress(const char *compressed, size_t compressed_length,
   return RawUncompress(compressed, compressed_length, uncompressed);
 }
 
-class BSSource : public Source
+struct BSSource : public Source
 {
 public:
   BSSource(BS *chunks, size_t nchunks, size_t size)

--- a/snappy.cabal
+++ b/snappy.cabal
@@ -1,3 +1,4 @@
+cabal-version:  2.2
 name:           snappy
 version:        0.2.0.2
 homepage:       http://github.com/bos/snappy
@@ -7,14 +8,13 @@ synopsis:
 description:
   This library provides fast, pure Haskell bindings to Google's Snappy
   compression and decompression library: <http://code.google.com/p/snappy/>
-license:        BSD3
+license:        BSD-3-Clause
 license-file:   LICENSE
 author:         Bryan O'Sullivan <bos@serpentine.com>
 maintainer:     Bryan O'Sullivan <bos@serpentine.com>
 copyright:      Copyright 2011 MailRank, Inc.
 category:       Codec, Compression
 build-type:     Simple
-cabal-version:  >= 1.8
 extra-source-files:
   README.md
   include/hs_snappy.h
@@ -23,11 +23,11 @@ extra-source-files:
   tests/Speedy.hs
 
 library
-  c-sources:       cbits/hs_snappy.cpp
+  cxx-sources:     cbits/hs_snappy.cpp
   include-dirs:    include
   extra-libraries: snappy stdc++
 
-  cc-options:      -Wall
+  cxx-options:     -Wall -std=c++17
   ghc-options:     -Wall
 
   build-depends:   base < 5, bytestring
@@ -40,6 +40,8 @@ library
 
   other-modules:
     Codec.Compression.Snappy.Internal
+
+  default-language: Haskell2010
 
 test-suite tests
   type:           exitcode-stdio-1.0
@@ -59,6 +61,8 @@ test-suite tests
     snappy,
     test-framework,
     test-framework-quickcheck2
+
+  default-language: Haskell2010
 
 source-repository head
   type:     git


### PR DESCRIPTION
### Overview

- Fix build errors on macOS Big Sur with Intel architecture
- Fix some build warnings

### Errors/warnings

* C++ build errors

```shell-session
$ stack build
snappy> configure (lib)
Configuring snappy-0.2.0.2...
snappy> build (lib)
Preprocessing library for snappy-0.2.0.2..
Building library for snappy-0.2.0.2..
[1 of 3] Compiling Codec.Compression.Snappy.Internal
[2 of 3] Compiling Codec.Compression.Snappy
[3 of 3] Compiling Codec.Compression.Snappy.Lazy

/Users/satosystems/Documents/git/snappy/Codec/Compression/Snappy/Lazy.hsc:52:10: warning: [-Wmissing-methods]
    • No explicit implementation for
        either ‘peek’ or ‘peekElemOff’ or ‘peekByteOff’
    • In the instance declaration for ‘Storable BS’
   |
52 | instance Storable BS where
   |          ^^^^^^^^^^^

/Users/satosystems/Documents/git/snappy/In file included from cbits/hs_snappy.cpp:2:0: error:

/Users/satosystems/Documents/git/snappy//usr/local/include/snappy.h:199:10: error:
     error: unknown type name 'constexpr'
      static constexpr int kBlockLog = 16;
             ^
    |
199 |   static constexpr int kBlockLog = 16;
    |          ^

/Users/satosystems/Documents/git/snappy//usr/local/include/snappy.h:200:10: error:
     error: unknown type name 'constexpr'
      static constexpr size_t kBlockSize = 1 << kBlockLog;
             ^
    |
200 |   static constexpr size_t kBlockSize = 1 << kBlockLog;
    |          ^

/Users/satosystems/Documents/git/snappy//usr/local/include/snappy.h:200:26: error:
     error: expected ';' after top level declarator
      static constexpr size_t kBlockSize = 1 << kBlockLog;
                             ^
                             ;
    |
200 |   static constexpr size_t kBlockSize = 1 << kBlockLog;
    |                          ^

/Users/satosystems/Documents/git/snappy//usr/local/include/snappy.h:202:10: error:
     error: unknown type name 'constexpr'
      static constexpr int kMinHashTableBits = 8;
             ^
    |
202 |   static constexpr int kMinHashTableBits = 8;
    |          ^

/Users/satosystems/Documents/git/snappy//usr/local/include/snappy.h:203:10: error:
     error: unknown type name 'constexpr'
      static constexpr size_t kMinHashTableSize = 1 << kMinHashTableBits;
             ^
    |
203 |   static constexpr size_t kMinHashTableSize = 1 << kMinHashTableBits;
    |          ^

/Users/satosystems/Documents/git/snappy//usr/local/include/snappy.h:203:26: error:
     error: expected ';' after top level declarator
      static constexpr size_t kMinHashTableSize = 1 << kMinHashTableBits;
                             ^
                             ;
    |
203 |   static constexpr size_t kMinHashTableSize = 1 << kMinHashTableBits;
    |                          ^

/Users/satosystems/Documents/git/snappy//usr/local/include/snappy.h:205:10: error:
     error: unknown type name 'constexpr'
      static constexpr int kMaxHashTableBits = 14;
             ^
    |
205 |   static constexpr int kMaxHashTableBits = 14;
    |          ^

/Users/satosystems/Documents/git/snappy//usr/local/include/snappy.h:206:10: error:
     error: unknown type name 'constexpr'
      static constexpr size_t kMaxHashTableSize = 1 << kMaxHashTableBits;
             ^
    |
206 |   static constexpr size_t kMaxHashTableSize = 1 << kMaxHashTableBits;
    |          ^

/Users/satosystems/Documents/git/snappy//usr/local/include/snappy.h:206:26: error:
     error: expected ';' after top level declarator
      static constexpr size_t kMaxHashTableSize = 1 << kMaxHashTableBits;
                             ^
                             ;
    |
206 |   static constexpr size_t kMaxHashTableSize = 1 << kMaxHashTableBits;
    |                          ^

/Users/satosystems/Documents/git/snappy/In file included from cbits/hs_snappy.cpp:3:0: error:

/Users/satosystems/Documents/git/snappy//usr/local/include/snappy-sinksource.h:43:42: error:
     error: unknown type name 'size_t'
      virtual void Append(const char* bytes, size_t n) = 0;
                                             ^
   |
43 |   virtual void Append(const char* bytes, size_t n) = 0;
   |                                          ^

/Users/satosystems/Documents/git/snappy//usr/local/include/snappy-sinksource.h:60:33: error:
     error: unknown type name 'size_t'
      virtual char* GetAppendBuffer(size_t length, char* scratch);
                                    ^
   |
60 |   virtual char* GetAppendBuffer(size_t length, char* scratch);
   |                                 ^

/Users/satosystems/Documents/git/snappy//usr/local/include/snappy-sinksource.h:74:20: error:
     error: unknown type name 'size_t'
          char* bytes, size_t n, void (*deleter)(void*, const char*, size_t),
                       ^
   |
74 |       char* bytes, size_t n, void (*deleter)(void*, const char*, size_t),
   |                    ^

/Users/satosystems/Documents/git/snappy//usr/local/include/snappy-sinksource.h:74:66: error:
     error: unknown type name 'size_t'
          char* bytes, size_t n, void (*deleter)(void*, const char*, size_t),
                                                                     ^
   |
74 |       char* bytes, size_t n, void (*deleter)(void*, const char*, size_t),
   |                                                                  ^

/Users/satosystems/Documents/git/snappy//usr/local/include/snappy-sinksource.h:101:7: error:
     error: unknown type name 'size_t'
          size_t min_size, size_t desired_size_hint, char* scratch,
          ^
    |
101 |       size_t min_size, size_t desired_size_hint, char* scratch,
    |       ^

/Users/satosystems/Documents/git/snappy//usr/local/include/snappy-sinksource.h:101:24: error:
     error: unknown type name 'size_t'
          size_t min_size, size_t desired_size_hint, char* scratch,
                           ^
    |
101 |       size_t min_size, size_t desired_size_hint, char* scratch,
    |                        ^

/Users/satosystems/Documents/git/snappy//usr/local/include/snappy-sinksource.h:102:7: error:
     error: unknown type name 'size_t'
          size_t scratch_size, size_t* allocated_size);
          ^
    |
102 |       size_t scratch_size, size_t* allocated_size);
    |       ^

/Users/satosystems/Documents/git/snappy//usr/local/include/snappy-sinksource.h:102:28: error:
     error: unknown type name 'size_t'
          size_t scratch_size, size_t* allocated_size);
                               ^
    |
102 |       size_t scratch_size, size_t* allocated_size);
    |                            ^

/Users/satosystems/Documents/git/snappy//usr/local/include/snappy-sinksource.h:117:11: error:
     error: unknown type name 'size_t'
      virtual size_t Available() const = 0;
              ^
    |
117 |   virtual size_t Available() const = 0;
    |           ^

/Users/satosystems/Documents/git/snappy//usr/local/include/snappy-sinksource.h:132:28: error:
     error: unknown type name 'size_t'
      virtual const char* Peek(size_t* len) = 0;
                               ^
    |
132 |   virtual const char* Peek(size_t* len) = 0;
    |                            ^
fatal error: too many errors emitted, stopping now [-ferror-limit=]
20 errors generated.
`gcc' failed in phase `C Compiler'. (Exit code: 1)

--  While building package snappy-0.2.0.2 (scroll up to its section to see the error) using:
      /Users/satosystems/.stack/setup-exe-cache/x86_64-osx/Cabal-simple_mPHDZzAJ_3.2.1.0_ghc-8.10.7 --builddir=.stack-work/dist/x86_64-osx/Cabal-3.2.1.0 build lib:snappy --ghc-options " -fdiagnostics-color=always"
    Process exited with code: ExitFailure 1
$
```

* stack build error

```shell-session
$ stack build
Unable to parse cabal file from package /Users/satosystems/Documents/git/snappy/snappy.cabal

- 11:21:
unexpected Unknown SPDX license identifier: 'BSD3' Do you mean BSD-3-Clause?
$
```

* C++ build warnings

```shell-session
$ stack build
snappy-0.2.0.2: unregistering (local file changes: Codec/Compression/Snappy.hs Codec/Compression/Snappy/Internal.hs Codec/Compression/Snappy/Lazy.hs...)
snappy> configure (lib)
Configuring snappy-0.2.0.2...
Warning: Packages using 'cabal-version: >= 1.10' must specify the
'default-language' field for each component (e.g. Haskell98 or Haskell2010).
If a component uses different languages in different modules then list the
other ones in the 'other-languages' field.
snappy> build (lib)
Preprocessing library for snappy-0.2.0.2..
Building library for snappy-0.2.0.2..
[1 of 3] Compiling Codec.Compression.Snappy.Internal
[2 of 3] Compiling Codec.Compression.Snappy
[3 of 3] Compiling Codec.Compression.Snappy.Lazy

/Users/satosystems/Documents/git/snappy/Codec/Compression/Snappy/Lazy.hsc:52:10: warning: [-Wmissing-methods]
    • No explicit implementation for
        either ‘peek’ or ‘peekElemOff’ or ‘peekByteOff’
    • In the instance declaration for ‘Storable BS’
   |
52 | instance Storable BS where
   |          ^^^^^^^^^^^

/Users/satosystems/Documents/git/snappy/cbits/hs_snappy.cpp:31:1: error:
     warning: 'BSSource' defined as a class here but previously declared as a struct; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Wmismatched-tags]
   |
31 | class BSSource : public Source
   | ^
class BSSource : public Source
^

/Users/satosystems/Documents/git/snappy/include/hs_snappy.h:36:1: error:  note: did you mean class here?
   |
36 | struct BSSource;
   | ^
struct BSSource;
^~~~~~
class
1 warning generated.

/Users/satosystems/Documents/git/snappy/cbits/hs_snappy.cpp:31:1: error:
     warning: 'BSSource' defined as a class here but previously declared as a struct; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Wmismatched-tags]
   |
31 | class BSSource : public Source
   | ^
class BSSource : public Source
^

/Users/satosystems/Documents/git/snappy/include/hs_snappy.h:36:1: error:  note: did you mean class here?
   |
36 | struct BSSource;
   | ^
struct BSSource;
^~~~~~
class
1 warning generated.
snappy> copy/register
Installing library in /Users/satosystems/Documents/git/snappy/.stack-work/install/x86_64-osx/4c903d6c62f2269443705b2b9e3cee6f76271142d85a3fb4635bc37009293177/8.10.7/lib/x86_64-osx-ghc-8.10.7/snappy-0.2.0.2-12m7LGoDROhBZXTpU5Sc8w
Registering library for snappy-0.2.0.2..
$
```

### Test result

```shell-session
$ stack test
snappy> test (suite: tests)

s_roundtrip: [OK, passed 100 tests]
t_rechunk: [OK, passed 100 tests]
compress_eq: [OK, passed 100 tests]
decompress_eq: [OK, passed 100 tests]
l_roundtrip: [OK, passed 100 tests]

         Properties  Total
 Passed  5           5
 Failed  0           0
 Total   5           5

snappy> Test suite tests passed
$
```
